### PR TITLE
Add support for v2 of dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for spatie/laravel-dashboard v2
 
 
 ## [1.0.1] - 2020-05-09

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The purpose of this package is to integrate the [ukfast/laravel-health-check](https://github.com/ukfast/laravel-health-check) package into a tile for [spatie/laravel-dashboard](https://github.com/spatie/laravel-dashboard).
 
-![Example Screenshot](/docs/example.png)
+![Example Screenshot](https://raw.githubusercontent.com/tylerwoonton/laravel-dashboard-health-check-tile/master/docs/example.png)
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     "require": {
         "php": "^7.4",
         "guzzlehttp/guzzle": "^6.5",
-        "illuminate/console": "^7.0",
-        "illuminate/http": "^7.0",
-        "illuminate/support": "^7.0",
-        "livewire/livewire": "^1.0",
-        "spatie/laravel-dashboard": "^1.0"
+        "illuminate/console": "^8.0",
+        "illuminate/http": "^8.0",
+        "illuminate/support": "^8.0",
+        "livewire/livewire": "^2.0",
+        "spatie/laravel-dashboard": "^2.0"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "spatie/laravel-dashboard": "^2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0",
+        "orchestra/testbench": "^6.0",
         "phpunit/phpunit": "^9.0"
     },
     "config": {


### PR DESCRIPTION
- Updates `spatie/laravel-dashboard` to `^2.0`
- Updates `livewire/livewire` to `^2.0`

Closes #1 